### PR TITLE
Add MariaDB support and registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ Official web page for Windows Longbridge.
 
 Use **admin** / **longbridge** to access the demo login page. A simple captcha protects the form.
 
-User data is stored in `data/users.db` (SQLite) which is automatically created on first login.
+User data is stored in a MariaDB database. Configure the connection using the `DB_HOST`, `DB_NAME`, `DB_USER` and `DB_PASS` environment variables. A default `admin/longbridge` account is inserted if none exists.

--- a/about.php
+++ b/about.php
@@ -11,6 +11,8 @@ include __DIR__ . '/includes/header.php';
     <li>Classic apps and retro widgets revived</li>
     <li>Longhorn and Vista sounds for nostalgia</li>
     <li>Stable Windows 10 base without bloat</li>
+    <li>Built-in Theme Manager lets you jump from Aero Hillel to Plex and tweak Start menu GUIs instantly</li>
+    <li>Upcoming update tool will deliver new builds with minimal fuss</li>
   </ul>
 </div>
 <div class="panel">

--- a/css/xp.css
+++ b/css/xp.css
@@ -100,7 +100,7 @@ nav li a:hover {
 
 .grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
   gap: 15px;
 }
 
@@ -109,13 +109,13 @@ nav li a:hover {
   border: 1px solid #a0a5b0;
   padding: 10px;
   display: flex;
-  align-items: flex-start;
-  gap: 10px;
+  align-items: center;
+  gap: 12px;
 }
 
 .card img {
-  width: 32px;
-  height: 32px;
+  width: 40px;
+  height: 40px;
 }
 
 .card h3 {

--- a/features.php
+++ b/features.php
@@ -56,4 +56,18 @@ include __DIR__ . '/includes/header.php';
     </div>
   </div>
 </div>
+
+<div class="panel">
+  <h2><img width="150" src="https://www.iconshock.com/image/Vista/General/settings" alt="">Customization &amp; Updates</h2>
+  <div class="grid">
+    <div class="card">
+      <img src="https://www.iconshock.com/image/Vista/General/magic_wand" alt="">
+      <div><h3>Theme Manager</h3><p>Switch between styles like Aero Hillel or Plex and tweak Start menu layouts instantly.</p></div>
+    </div>
+    <div class="card">
+      <img src="https://www.iconshock.com/image/Vista/General/download" alt="">
+      <div><h3>Integrated Update Tool</h3><p>Planned utility to keep Longbridge current with one click.</p></div>
+    </div>
+  </div>
+</div>
 <?php include __DIR__ . '/includes/footer.php'; ?>

--- a/includes/db.php
+++ b/includes/db.php
@@ -1,11 +1,15 @@
 <?php
-$dbFile = __DIR__ . '/../data/users.db';
-$init = !file_exists($dbFile);
+$dbHost = getenv('DB_HOST') ?: 'localhost';
+$dbName = getenv('DB_NAME') ?: 'longbridge';
+$dbUser = getenv('DB_USER') ?: 'root';
+$dbPass = getenv('DB_PASS') ?: '';
 try {
-    $db = new PDO('sqlite:' . $dbFile);
+    $db = new PDO("mysql:host=$dbHost;dbname=$dbName;charset=utf8mb4", $dbUser, $dbPass);
     $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-    if ($init) {
-        $db->exec("CREATE TABLE users (id INTEGER PRIMARY KEY, username TEXT UNIQUE, password TEXT);");
+    $db->exec("CREATE TABLE IF NOT EXISTS users (id INT AUTO_INCREMENT PRIMARY KEY, username VARCHAR(255) UNIQUE, password VARCHAR(255))");
+    $check = $db->prepare('SELECT COUNT(*) FROM users WHERE username = ?');
+    $check->execute(['admin']);
+    if (!$check->fetchColumn()) {
         $hash = password_hash('longbridge', PASSWORD_DEFAULT);
         $stmt = $db->prepare('INSERT INTO users (username, password) VALUES (?, ?)');
         $stmt->execute(['admin', $hash]);

--- a/includes/header.php
+++ b/includes/header.php
@@ -33,6 +33,7 @@ if (!isset($currentPage)) {
       <li><a href="/logout.php"><img height="40" width="40" src="https://www.iconshock.com/image/Vista/General/logout" alt="Logout">Logout</a></li>
       <?php else: ?>
       <li><a <?php if($currentPage=='login') echo 'class="active"'; ?> href="/login.php"><img height="40" width="40" src="https://www.iconshock.com/image/Vista/General/lock" alt="Login">Login</a></li>
+      <li><a <?php if($currentPage=='register') echo 'class="active"'; ?> href="/register.php"><img height="40" width="40" src="https://www.iconshock.com/image/Vista/General/add_user" alt="Register">Register</a></li>
       <?php endif; ?>
     </ul>
   </nav>

--- a/register.php
+++ b/register.php
@@ -1,0 +1,51 @@
+<?php
+session_start();
+require __DIR__ . '/includes/db.php';
+$error = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $user = trim($_POST['username'] ?? '');
+    $pass = $_POST['password'] ?? '';
+    $captcha = $_POST['captcha'] ?? '';
+    if (strcasecmp($captcha, $_SESSION['captcha_text'] ?? '') !== 0) {
+        $error = 'Captcha incorrect';
+    } elseif ($user === '' || $pass === '') {
+        $error = 'Please fill all fields';
+    } else {
+        $stmt = $db->prepare('SELECT id FROM users WHERE username = ?');
+        $stmt->execute([$user]);
+        if ($stmt->fetch()) {
+            $error = 'Username already taken';
+        } else {
+            $hash = password_hash($pass, PASSWORD_DEFAULT);
+            $insert = $db->prepare('INSERT INTO users (username, password) VALUES (?, ?)');
+            $insert->execute([$user, $hash]);
+            $_SESSION['user'] = $user;
+            header('Location: /');
+            exit;
+        }
+    }
+}
+$title = 'Register';
+$currentPage = 'register';
+include __DIR__ . '/includes/header.php';
+?>
+<div class="panel">
+  <h2>Register</h2>
+  <?php if ($error): ?>
+  <p style="color:red;"><strong><?php echo htmlspecialchars($error); ?></strong></p>
+  <?php endif; ?>
+  <form method="post" action="register.php">
+    <p>
+      <label>Username: <input type="text" name="username"></label>
+    </p>
+    <p>
+      <label>Password: <input type="password" name="password"></label>
+    </p>
+    <p>
+      <img src="captcha.php" alt="captcha"><br>
+      <label>Enter text: <input type="text" name="captcha"></label>
+    </p>
+    <button type="submit">Register</button>
+  </form>
+</div>
+<?php include __DIR__ . '/includes/footer.php'; ?>


### PR DESCRIPTION
## Summary
- switch from SQLite to MariaDB
- add user registration page
- show register link in the navbar
- make feature cards wider and add section about Theme Manager and updater
- document new DB usage

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_685c212214188320ad465935ee3124e7