### PR TITLE
Add rate limiting and improve captcha

### DIFF
--- a/captcha.php
+++ b/captcha.php
@@ -1,5 +1,7 @@
 <?php
 session_start();
+require __DIR__ . '/includes/ratelimit.php';
+rateLimit('captcha', 20, 60);
 $code = substr(str_shuffle('ABCDEFGHJKLMNPQRSTUVWXYZ23456789'), 0, 5);
 $_SESSION['captcha_text'] = $code;
 header('Content-Type: application/json');

--- a/includes/ratelimit.php
+++ b/includes/ratelimit.php
@@ -1,0 +1,48 @@
+<?php
+function rateLimit(string $action, int $limit = 10, int $window = 60): void {
+    $file = __DIR__ . '/../data/ratelimit.json';
+    if (!file_exists($file)) {
+        file_put_contents($file, '{}');
+    }
+    $fp = fopen($file, 'c+');
+    if (!$fp) {
+        return; // fail open: skip limiting
+    }
+    flock($fp, LOCK_EX);
+    $contents = stream_get_contents($fp);
+    $data = json_decode($contents ?: '{}', true);
+    if (!is_array($data)) {
+        $data = [];
+    }
+    $ip = $_SERVER['REMOTE_ADDR'] ?? 'unknown';
+    $key = $ip . ':' . $action;
+    $now = time();
+    foreach ($data as $k => $v) {
+        if (($v['expires'] ?? 0) < $now) {
+            unset($data[$k]);
+        }
+    }
+    if (isset($data[$key])) {
+        $entry = $data[$key];
+        if ($entry['expires'] > $now) {
+            $entry['count']++;
+        } else {
+            $entry = ['count' => 1, 'expires' => $now + $window];
+        }
+    } else {
+        $entry = ['count' => 1, 'expires' => $now + $window];
+    }
+    $data[$key] = $entry;
+    ftruncate($fp, 0);
+    rewind($fp);
+    fwrite($fp, json_encode($data));
+    fflush($fp);
+    flock($fp, LOCK_UN);
+    fclose($fp);
+    if ($entry['count'] > $limit) {
+        header('HTTP/1.1 429 Too Many Requests');
+        echo 'Too many requests. Please slow down.';
+        exit;
+    }
+}
+?>

--- a/js/captcha.js
+++ b/js/captcha.js
@@ -5,19 +5,21 @@ function loadCaptcha() {
     .then(r => r.json())
     .then(d => {
       const canvas = document.createElement('canvas');
-      canvas.width = 100;
-      canvas.height = 30;
+      canvas.width = 130;
+      canvas.height = 40;
       const ctx = canvas.getContext('2d');
       ctx.fillStyle = 'rgb(224,236,244)';
       ctx.fillRect(0, 0, canvas.width, canvas.height);
-      ctx.font = '20px sans-serif';
-      ctx.fillStyle = '#000';
+      ctx.font = 'bold 22px "Comic Sans MS", Tahoma, sans-serif';
       ctx.textBaseline = 'middle';
-      ctx.fillText(d.code, 15, 15);
+      for (let i = 0; i < d.code.length; i++) {
+        ctx.fillStyle = `hsl(${Math.floor(Math.random()*360)},70%,40%)`;
+        ctx.fillText(d.code[i], 10 + i * 22, 20);
+      }
       const logo = new Image();
       logo.crossOrigin = 'anonymous';
       logo.onload = () => {
-        ctx.drawImage(logo, 70, 5, 20, 20);
+        ctx.drawImage(logo, 104, 8, 24, 24);
         img.src = canvas.toDataURL('image/png');
       };
       logo.src = '/data/logolol.png';

--- a/login.php
+++ b/login.php
@@ -1,8 +1,10 @@
 <?php
 session_start();
 require __DIR__ . '/includes/db.php';
+require __DIR__ . '/includes/ratelimit.php';
 $error = '';
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    rateLimit('login', 5, 60);
     $user = $_POST['username'] ?? '';
     $pass = $_POST['password'] ?? '';
     $captcha = $_POST['captcha'] ?? '';

--- a/register.php
+++ b/register.php
@@ -1,8 +1,10 @@
 <?php
 session_start();
 require __DIR__ . '/includes/db.php';
+require __DIR__ . '/includes/ratelimit.php';
 $error = '';
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    rateLimit('register', 5, 60);
     $user = trim($_POST['username'] ?? '');
     $pass = $_POST['password'] ?? '';
     $captcha = $_POST['captcha'] ?? '';


### PR DESCRIPTION
## Summary
- add a simple file-based rate limiter
- apply the limiter to login, registration and captcha endpoints
- redesign captcha image with larger canvas and colorful letters

## Testing
- `php -l` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685c302776f48320a0e6a6c6f05a39c7