### PR TITLE
Remove logo from captcha

### DIFF
--- a/js/captcha.js
+++ b/js/captcha.js
@@ -16,13 +16,7 @@ function loadCaptcha() {
         ctx.fillStyle = `hsl(${Math.floor(Math.random()*360)},70%,40%)`;
         ctx.fillText(d.code[i], 10 + i * 22, 20);
       }
-      const logo = new Image();
-      logo.crossOrigin = 'anonymous';
-      logo.onload = () => {
-        ctx.drawImage(logo, 104, 8, 24, 24);
-        img.src = canvas.toDataURL('image/png');
-      };
-      logo.src = '/data/logolol.png';
+      img.src = canvas.toDataURL('image/png');
     });
 }
 document.addEventListener('DOMContentLoaded', loadCaptcha);


### PR DESCRIPTION
## Summary
- remove logo image draw call from captcha rendering

## Testing
- `php -l login.php register.php captcha.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685c3213e1ac8320b9c9499445cbee32