### PR TITLE
Add simple chatroom for logged in users

### DIFF
--- a/chat.php
+++ b/chat.php
@@ -1,0 +1,21 @@
+<?php
+session_start();
+if (!isset($_SESSION['user'])) {
+    header('Location: /login.aspx');
+    exit;
+}
+$title = 'Chat';
+$currentPage = 'chat';
+include __DIR__ . '/includes/header.php';
+?>
+<div class="panel chat-panel">
+  <h2><img width="40" src="https://upload.wikimedia.org/wikipedia/en/b/bf/Windows_Live_Messenger_icon.png" alt="">Chatroom</h2>
+  <div id="chat-window" class="chat-window"></div>
+  <form id="chat-form" class="chat-form">
+    <input type="text" id="chat-input" maxlength="250" placeholder="Type a message" autocomplete="off">
+    <button type="submit">Send</button>
+  </form>
+</div>
+<script src="/js/chat.js"></script>
+<?php include __DIR__ . '/includes/footer.php'; ?>
+

--- a/css/xp.css
+++ b/css/xp.css
@@ -229,3 +229,40 @@ footer .sidebar li {
     grid-template-columns: 1fr;
   }
 }
+/* Chat styles */
+.chat-panel {
+  max-width: 600px;
+  margin: 0 auto;
+}
+.chat-window {
+  background: #fff;
+  border: 1px solid #a0a5b0;
+  height: 300px;
+  overflow-y: auto;
+  padding: 5px;
+  margin-bottom: 10px;
+}
+.chat-form {
+  display: flex;
+  gap: 6px;
+}
+.chat-form input[type="text"] {
+  flex: 1;
+  padding: 4px;
+}
+.chat-message {
+  margin-bottom: 6px;
+  background: #e8ecf4;
+  padding: 4px 6px;
+  border-radius: 4px;
+}
+.chat-message.own {
+  background: #d0e4ff;
+}
+.chat-message .sender {
+  font-weight: bold;
+}
+.chat-message .time {
+  color: #555;
+  font-size: 11px;
+}

--- a/fetch_messages.php
+++ b/fetch_messages.php
@@ -1,0 +1,17 @@
+<?php
+session_start();
+if (!isset($_SESSION['user'])) {
+    http_response_code(403);
+    exit;
+}
+require __DIR__ . '/includes/db.php';
+$limit = 50;
+$stmt = $db->prepare('SELECT username, message, created FROM messages ORDER BY id DESC LIMIT ?');
+$stmt->bindValue(1, $limit, PDO::PARAM_INT);
+$stmt->execute();
+$messages = array_reverse($stmt->fetchAll(PDO::FETCH_ASSOC));
+header('Content-Type: application/json');
+header('Cache-Control: no-cache');
+echo json_encode($messages);
+
+

--- a/includes/db.php
+++ b/includes/db.php
@@ -7,6 +7,7 @@ try {
     $db = new PDO("mysql:host=$dbHost;dbname=$dbName;charset=utf8mb4", $dbUser, $dbPass);
     $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
     $db->exec("CREATE TABLE IF NOT EXISTS users (id INT AUTO_INCREMENT PRIMARY KEY, username VARCHAR(255) UNIQUE, password VARCHAR(255))");
+    $db->exec("CREATE TABLE IF NOT EXISTS messages (id INT AUTO_INCREMENT PRIMARY KEY, username VARCHAR(255), message TEXT, created TIMESTAMP DEFAULT CURRENT_TIMESTAMP)");
     $check = $db->prepare('SELECT COUNT(*) FROM users WHERE username = ?');
     $check->execute(['admin']);
     if (!$check->fetchColumn()) {

--- a/includes/header.php
+++ b/includes/header.php
@@ -29,6 +29,7 @@ if (!isset($currentPage)) {
       <li><a href="https://discord.gg/zP9fAPxtNj"><img height="40" width="40" src="https://upload.wikimedia.org/wikipedia/en/b/bf/Windows_Live_Messenger_icon.png" alt="Community">Community</a></li>
       <li><a <?php if($currentPage=='about') echo 'class="active"'; ?> href="/about.aspx"><img height="40" width="40" src="https://www.iconshock.com/image/Vista/General/file" alt="About">About</a></li>
       <?php if(isset($_SESSION['user'])): ?>
+      <li><a <?php if($currentPage=='chat') echo 'class="active"'; ?> href="/chat.aspx"><img height="40" width="40" src="https://upload.wikimedia.org/wikipedia/en/b/bf/Windows_Live_Messenger_icon.png" alt="Chat">Chat</a></li>
       <li class="welcome">Welcome, <?php echo htmlspecialchars($_SESSION['user']); ?></li>
       <li><a href="/logout.aspx"><img height="20" width="20" src="https://www.iconshock.com/image/Windows7/General/cross" alt="Logout">Logout</a></li>
       <?php else: ?>

--- a/js/chat.js
+++ b/js/chat.js
@@ -1,0 +1,45 @@
+function escapeHtml(text) {
+  const div = document.createElement('div');
+  div.appendChild(document.createTextNode(text));
+  return div.innerHTML;
+}
+
+function renderMessages(msgs) {
+  const win = document.getElementById('chat-window');
+  win.innerHTML = '';
+  msgs.forEach(m => {
+    const item = document.createElement('div');
+    item.className = 'chat-message' + (m.username === window.currentUser ? ' own' : '');
+    item.innerHTML = `<span class="sender">${escapeHtml(m.username)}</span> ` +
+                     `<span class="time">${escapeHtml(m.created)}</span><br>` +
+                     `<span class="text">${escapeHtml(m.message)}</span>`;
+    win.appendChild(item);
+  });
+  win.scrollTop = win.scrollHeight;
+}
+
+function fetchMessages() {
+  fetch('fetch_messages.php')
+    .then(r => r.json())
+    .then(renderMessages);
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  window.currentUser = document.querySelector('.welcome')?.textContent.replace('Welcome, ','');
+  const form = document.getElementById('chat-form');
+  form.addEventListener('submit', e => {
+    e.preventDefault();
+    const input = document.getElementById('chat-input');
+    const msg = input.value.trim();
+    if (!msg) return;
+    fetch('send_message.php', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: 'message=' + encodeURIComponent(msg)
+    }).then(fetchMessages);
+    input.value = '';
+  });
+  fetchMessages();
+  setInterval(fetchMessages, 3000);
+});
+

--- a/send_message.php
+++ b/send_message.php
@@ -1,0 +1,20 @@
+<?php
+session_start();
+if (!isset($_SESSION['user'])) {
+    http_response_code(403);
+    exit;
+}
+require __DIR__ . '/includes/db.php';
+require __DIR__ . '/includes/ratelimit.php';
+rateLimit('chat', 10, 10);
+$input = trim($_POST['message'] ?? '');
+if ($input === '') {
+    exit;
+}
+if (mb_strlen($input) > 250) {
+    $input = mb_substr($input, 0, 250);
+}
+$stmt = $db->prepare('INSERT INTO messages (username, message) VALUES (?, ?)');
+$stmt->execute([$_SESSION['user'], $input]);
+?>
+


### PR DESCRIPTION
## Summary
- set up `messages` table in db initialization
- create `chat.php` along with AJAX helpers for fetching/sending messages
- add a Windows Live Messenger-style chat UI
- link chatroom from navigation when logged in

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685c341cc02c8320adbaeb4cc5d38937