### PR TITLE
Add chat channels and account settings

### DIFF
--- a/account.php
+++ b/account.php
@@ -1,0 +1,44 @@
+<?php
+session_start();
+if (!isset($_SESSION['user'])) {
+    header('Location: /login.aspx');
+    exit;
+}
+require __DIR__ . '/includes/db.php';
+
+$error = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $pic = trim($_POST['profile_pic'] ?? '');
+    if ($pic !== '' && !preg_match('/^https?:\/\//i', $pic)) {
+        $error = 'Profile picture must be a valid URL';
+    } else {
+        $stmt = $db->prepare('UPDATE users SET profile_pic = ? WHERE username = ?');
+        $stmt->execute([$pic ?: null, $_SESSION['user']]);
+        $_SESSION['profile_pic'] = $pic ?: null;
+        header('Location: /account.aspx?updated=1');
+        exit;
+    }
+}
+
+$title = 'Account Settings';
+$currentPage = 'account';
+include __DIR__ . '/includes/header.php';
+?>
+<div class="panel">
+  <h2>Account Settings</h2>
+  <?php if (isset($_GET['updated'])): ?>
+  <p style="color:green;"><strong>Profile updated.</strong></p>
+  <?php endif; ?>
+  <?php if ($error): ?>
+  <p style="color:red;"><strong><?php echo htmlspecialchars($error); ?></strong></p>
+  <?php endif; ?>
+  <form method="post" action="account.aspx">
+    <p>
+      <label>Profile picture URL:<br>
+        <input type="text" name="profile_pic" value="<?php echo htmlspecialchars($_SESSION['profile_pic'] ?? ''); ?>" size="50">
+      </label>
+    </p>
+    <button type="submit">Save</button>
+  </form>
+</div>
+<?php include __DIR__ . '/includes/footer.php'; ?>

--- a/chat.php
+++ b/chat.php
@@ -12,6 +12,11 @@ include __DIR__ . '/includes/header.php';
   <h2><img width="40" src="https://upload.wikimedia.org/wikipedia/en/b/bf/Windows_Live_Messenger_icon.png" alt="">Chatroom</h2>
   <div id="chat-window" class="chat-window"></div>
   <form id="chat-form" class="chat-form">
+    <select id="chat-channel">
+      <option value="general">General</option>
+      <option value="tech">Tech</option>
+      <option value="offtopic">Off-topic</option>
+    </select>
     <input type="text" id="chat-input" maxlength="250" placeholder="Type a message" autocomplete="off">
     <button type="submit">Send</button>
   </form>

--- a/css/xp.css
+++ b/css/xp.css
@@ -54,6 +54,12 @@ nav ul {
   font-weight: bold;
   color: #003399;
 }
+.avatar-small {
+  width: 24px;
+  height: 24px;
+  border-radius: 3px;
+  margin-right: 4px;
+}
 
 nav li a {
   display: flex;
@@ -245,6 +251,9 @@ footer .sidebar li {
 .chat-form {
   display: flex;
   gap: 6px;
+}
+.chat-form select {
+  padding: 4px;
 }
 .chat-form input[type="text"] {
   flex: 1;

--- a/fetch_messages.php
+++ b/fetch_messages.php
@@ -4,10 +4,12 @@ if (!isset($_SESSION['user'])) {
     http_response_code(403);
     exit;
 }
+$channel = $_GET['channel'] ?? 'general';
 require __DIR__ . '/includes/db.php';
 $limit = 50;
-$stmt = $db->prepare('SELECT username, message, created FROM messages ORDER BY id DESC LIMIT ?');
-$stmt->bindValue(1, $limit, PDO::PARAM_INT);
+$stmt = $db->prepare('SELECT username, message, created FROM messages WHERE channel = ? ORDER BY id DESC LIMIT ?');
+$stmt->bindValue(1, $channel, PDO::PARAM_STR);
+$stmt->bindValue(2, $limit, PDO::PARAM_INT);
 $stmt->execute();
 $messages = array_reverse($stmt->fetchAll(PDO::FETCH_ASSOC));
 header('Content-Type: application/json');

--- a/includes/db.php
+++ b/includes/db.php
@@ -6,8 +6,17 @@ $dbPass = getenv('DB_PASS') ?: '';
 try {
     $db = new PDO("mysql:host=$dbHost;dbname=$dbName;charset=utf8mb4", $dbUser, $dbPass);
     $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-    $db->exec("CREATE TABLE IF NOT EXISTS users (id INT AUTO_INCREMENT PRIMARY KEY, username VARCHAR(255) UNIQUE, password VARCHAR(255))");
-    $db->exec("CREATE TABLE IF NOT EXISTS messages (id INT AUTO_INCREMENT PRIMARY KEY, username VARCHAR(255), message TEXT, created TIMESTAMP DEFAULT CURRENT_TIMESTAMP)");
+    $db->exec("CREATE TABLE IF NOT EXISTS users (id INT AUTO_INCREMENT PRIMARY KEY, username VARCHAR(255) UNIQUE, password VARCHAR(255), profile_pic VARCHAR(255) NULL)");
+    $db->exec("CREATE TABLE IF NOT EXISTS messages (id INT AUTO_INCREMENT PRIMARY KEY, username VARCHAR(255), message TEXT, channel VARCHAR(100) DEFAULT 'general', created TIMESTAMP DEFAULT CURRENT_TIMESTAMP)");
+    // ensure new columns exist when updating from older installations
+    $cols = $db->query("SHOW COLUMNS FROM users LIKE 'profile_pic'")->fetchAll();
+    if (!$cols) {
+        $db->exec("ALTER TABLE users ADD COLUMN profile_pic VARCHAR(255) NULL");
+    }
+    $cols = $db->query("SHOW COLUMNS FROM messages LIKE 'channel'")->fetchAll();
+    if (!$cols) {
+        $db->exec("ALTER TABLE messages ADD COLUMN channel VARCHAR(100) DEFAULT 'general'");
+    }
     $check = $db->prepare('SELECT COUNT(*) FROM users WHERE username = ?');
     $check->execute(['admin']);
     if (!$check->fetchColumn()) {

--- a/includes/header.php
+++ b/includes/header.php
@@ -30,7 +30,13 @@ if (!isset($currentPage)) {
       <li><a <?php if($currentPage=='about') echo 'class="active"'; ?> href="/about.aspx"><img height="40" width="40" src="https://www.iconshock.com/image/Vista/General/file" alt="About">About</a></li>
       <?php if(isset($_SESSION['user'])): ?>
       <li><a <?php if($currentPage=='chat') echo 'class="active"'; ?> href="/chat.aspx"><img height="40" width="40" src="https://upload.wikimedia.org/wikipedia/en/b/bf/Windows_Live_Messenger_icon.png" alt="Chat">Chat</a></li>
-      <li class="welcome">Welcome, <?php echo htmlspecialchars($_SESSION['user']); ?></li>
+      <li><a <?php if($currentPage=='account') echo 'class="active"'; ?> href="/account.aspx"><img height="40" width="40" src="https://www.iconshock.com/image/Windows7/General/user" alt="Account">Account</a></li>
+      <li class="welcome">
+        <?php if(!empty($_SESSION['profile_pic'])): ?>
+          <img class="avatar-small" src="<?php echo htmlspecialchars($_SESSION['profile_pic']); ?>" alt="avatar">
+        <?php endif; ?>
+        Welcome, <?php echo htmlspecialchars($_SESSION['user']); ?>
+      </li>
       <li><a href="/logout.aspx"><img height="20" width="20" src="https://www.iconshock.com/image/Windows7/General/cross" alt="Logout">Logout</a></li>
       <?php else: ?>
       <li><a <?php if($currentPage=='login') echo 'class="active"'; ?> href="/login.aspx"><img height="40" width="40" src="https://www.iconshock.com/image/Vista/General/lock" alt="Login">Login</a></li>

--- a/js/chat.js
+++ b/js/chat.js
@@ -18,8 +18,12 @@ function renderMessages(msgs) {
   win.scrollTop = win.scrollHeight;
 }
 
+function getChannel() {
+  return document.getElementById('chat-channel').value;
+}
+
 function fetchMessages() {
-  fetch('fetch_messages.php')
+  fetch('fetch_messages.php?channel=' + encodeURIComponent(getChannel()))
     .then(r => r.json())
     .then(renderMessages);
 }
@@ -27,6 +31,7 @@ function fetchMessages() {
 document.addEventListener('DOMContentLoaded', () => {
   window.currentUser = document.querySelector('.welcome')?.textContent.replace('Welcome, ','');
   const form = document.getElementById('chat-form');
+  const channelSelect = document.getElementById('chat-channel');
   form.addEventListener('submit', e => {
     e.preventDefault();
     const input = document.getElementById('chat-input');
@@ -35,10 +40,11 @@ document.addEventListener('DOMContentLoaded', () => {
     fetch('send_message.php', {
       method: 'POST',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      body: 'message=' + encodeURIComponent(msg)
+      body: 'message=' + encodeURIComponent(msg) + '&channel=' + encodeURIComponent(getChannel())
     }).then(fetchMessages);
     input.value = '';
   });
+  channelSelect.addEventListener('change', fetchMessages);
   fetchMessages();
   setInterval(fetchMessages, 3000);
 });

--- a/login.php
+++ b/login.php
@@ -11,11 +11,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (strcasecmp($captcha, $_SESSION['captcha_text'] ?? '') !== 0) {
         $error = 'Captcha incorrect';
     } else {
-        $stmt = $db->prepare('SELECT password FROM users WHERE username = ?');
+        $stmt = $db->prepare('SELECT password, profile_pic FROM users WHERE username = ?');
         $stmt->execute([$user]);
         $row = $stmt->fetch(PDO::FETCH_ASSOC);
         if ($row && password_verify($pass, $row['password'])) {
             $_SESSION['user'] = $user;
+            $_SESSION['profile_pic'] = $row['profile_pic'] ?? null;
             header('Location: /');
             exit;
         } else {

--- a/register.php
+++ b/register.php
@@ -22,6 +22,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $insert = $db->prepare('INSERT INTO users (username, password) VALUES (?, ?)');
             $insert->execute([$user, $hash]);
             $_SESSION['user'] = $user;
+            $_SESSION['profile_pic'] = null;
             header('Location: /');
             exit;
         }

--- a/send_message.php
+++ b/send_message.php
@@ -8,13 +8,20 @@ require __DIR__ . '/includes/db.php';
 require __DIR__ . '/includes/ratelimit.php';
 rateLimit('chat', 10, 10);
 $input = trim($_POST['message'] ?? '');
+$channel = $_POST['channel'] ?? 'general';
 if ($input === '') {
     exit;
 }
 if (mb_strlen($input) > 250) {
     $input = mb_substr($input, 0, 250);
 }
-$stmt = $db->prepare('INSERT INTO messages (username, message) VALUES (?, ?)');
-$stmt->execute([$_SESSION['user'], $input]);
+$check = $db->prepare('SELECT message, created FROM messages WHERE username = ? ORDER BY id DESC LIMIT 1');
+$check->execute([$_SESSION['user']]);
+$last = $check->fetch(PDO::FETCH_ASSOC);
+if ($last && $last['message'] === $input && strtotime($last['created']) > time() - 30) {
+    exit; // ignore spammy duplicate
+}
+$stmt = $db->prepare('INSERT INTO messages (username, message, channel) VALUES (?, ?, ?)');
+$stmt->execute([$_SESSION['user'], $input, $channel]);
 ?>
 


### PR DESCRIPTION
## Summary
- add account settings page with profile picture support
- display avatar and account link in nav
- support chat channels with a dropdown selector
- add duplicate message spam filter
- store avatar URL and chat channel in DB

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685c36aab3e483208f915d322eedcd14