### PR TITLE
Fix nudge loop and add WLM styling

### DIFF
--- a/css/xp.css
+++ b/css/xp.css
@@ -311,3 +311,16 @@ footer .sidebar li {
   75% { transform: translate(-2px, 2px); }
   100% { transform: translate(0, 0); }
 }
+
+/* WLM inspired aerobutton styles from garcia-clara/windows-live-messenger */
+.aerobutton {
+  background-color: transparent;
+  border: 2px solid transparent;
+}
+.aerobutton:hover {
+  border-image: url('/img/wlm/general/aerobutton_border.png') 2 round;
+  background-size: 100% 100%;
+}
+.aerobutton:active {
+  border-image: url('/img/wlm/general/aerobutton_border_down.png') 2 round;
+}

--- a/fetch_messages.php
+++ b/fetch_messages.php
@@ -7,7 +7,7 @@ if (!isset($_SESSION['user'])) {
 $channel = $_GET['channel'] ?? 'general';
 require __DIR__ . '/includes/db.php';
 $limit = 50;
-$stmt = $db->prepare('SELECT username, message, created FROM messages WHERE channel = ? ORDER BY id DESC LIMIT ?');
+$stmt = $db->prepare('SELECT id, username, message, created FROM messages WHERE channel = ? ORDER BY id DESC LIMIT ?');
 $stmt->bindValue(1, $channel, PDO::PARAM_STR);
 $stmt->bindValue(2, $limit, PDO::PARAM_INT);
 $stmt->execute();

--- a/includes/header.php
+++ b/includes/header.php
@@ -17,6 +17,7 @@ if (!isset($currentPage)) {
 <title><?php echo htmlspecialchars($title); ?></title>
 <link rel="icon" href="/favicon.ico" type="image/x-icon">
 <link rel="stylesheet" href="/css/xp.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/7.css">
 </head>
 <body>
 <div class="top-banner">Build 2 of <strong>Windows Longbridge</strong> is out!</div>

--- a/js/chat.js
+++ b/js/chat.js
@@ -4,12 +4,18 @@ function escapeHtml(text) {
   return div.innerHTML;
 }
 
+let lastMessageId = 0;
+
 function renderMessages(msgs) {
   const win = document.getElementById('chat-window');
   win.innerHTML = '';
+  let highest = lastMessageId;
   msgs.forEach(m => {
+    if (m.id > highest) highest = m.id;
     if (m.message === '::nudge::') {
-      nudge();
+      if (m.id > lastMessageId) {
+        nudge();
+      }
       const item = document.createElement('div');
       item.className = 'chat-message system';
       item.textContent = m.username + ' sent a nudge!';
@@ -23,6 +29,7 @@ function renderMessages(msgs) {
                      `<span class="text">${escapeHtml(m.message)}</span>`;
     win.appendChild(item);
   });
+  lastMessageId = highest;
   win.scrollTop = win.scrollHeight;
 }
 
@@ -71,7 +78,10 @@ document.addEventListener('DOMContentLoaded', () => {
     }).then(fetchMessages);
     input.value = '';
   });
-  channelSelect.addEventListener('change', fetchMessages);
+  channelSelect.addEventListener('change', () => {
+    lastMessageId = 0;
+    fetchMessages();
+  });
   nudgeBtn.addEventListener('click', () => {
     fetch('send_message.php', {
       method: 'POST',


### PR DESCRIPTION
## Summary
- prevent repeated nudges by tracking last seen message ID
- return message `id` in `fetch_messages.php`
- include 7.css for additional Windows styling
- add aerobutton styles from the WLM project

## Testing
- `php -l chat.php`
- `for f in *.php includes/*.php; do php -l $f || break; done`


------
https://chatgpt.com/codex/tasks/task_b_685c476196a0832083737538315a9eeb