### PR TITLE
Improve chatroom UI and add nudge sound

### DIFF
--- a/chat.php
+++ b/chat.php
@@ -19,9 +19,10 @@ include __DIR__ . '/includes/header.php';
       <option value="offtopic">Off-topic</option>
     </select>
     <input type="text" id="chat-input" maxlength="250" placeholder="Type a message" autocomplete="off">
-    <button type="button" id="nudge-btn" aria-label="Nudge"></button>
-    <button type="submit" aria-label="Send"></button>
+    <button type="button" id="nudge-btn" class="aerobutton" aria-label="Nudge"></button>
+    <button type="submit" class="aerobutton" aria-label="Send"></button>
   </form>
+  <audio id="nudge-sound" src="/img/nudge.mp3" preload="auto"></audio>
 </div>
 <script src="/js/chat.js"></script>
 <?php include __DIR__ . '/includes/footer.php'; ?>

--- a/css/xp.css
+++ b/css/xp.css
@@ -237,10 +237,27 @@ footer .sidebar li {
 }
 /* Chat styles */
 .chat-panel {
-  max-width: 600px;
+  max-width: 476px;
   margin: 0 auto;
   background: url('/img/wlm/background/chat_header.png') no-repeat top center;
   padding-top: 40px;
+  position: relative;
+}
+
+.chat-panel h2 {
+  position: absolute;
+  top: 8px;
+  left: 0;
+  width: 100%;
+  text-align: center;
+  color: #fff;
+  border: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  justify-content: center;
+  gap: 6px;
+  align-items: center;
 }
 .chat-window {
   background: #fff url('/img/wlm/background/chat_icons_background.png') repeat-x top;
@@ -262,7 +279,8 @@ footer .sidebar li {
   background: url('/img/wlm/general/arrow.png') no-repeat center;
   width: 32px;
   height: 32px;
-  border: none;
+  border: 2px solid transparent;
+  background-color: transparent;
 }
 .chat-form button:hover {
   background-image: url('/img/wlm/general/arrow_white.png');
@@ -276,10 +294,12 @@ footer .sidebar li {
 }
 .chat-form select {
   padding: 4px;
+  border: 1px solid #a0a5b0;
 }
 .chat-form input[type="text"] {
   flex: 1;
   padding: 4px;
+  border: 1px solid #a0a5b0;
 }
 .chat-message {
   margin-bottom: 6px;

--- a/js/chat.js
+++ b/js/chat.js
@@ -52,6 +52,11 @@ function nudge() {
   const panel = document.querySelector('.chat-panel');
   if (!panel) return;
   panel.classList.add('nudge');
+  const audio = document.getElementById('nudge-sound');
+  if (audio) {
+    audio.currentTime = 0;
+    audio.play().catch(() => {});
+  }
   setTimeout(() => panel.classList.remove('nudge'), 500);
 }
 


### PR DESCRIPTION
## Summary
- tweak chat panel layout to fit the Windows Live Messenger header
- style chat buttons with aerobuttons
- add nudge sound playback
- apply minor input styling

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_b_685c49f5b8f08320ab444c8caab596dd