### PR TITLE
Add emoji picker and message limit

### DIFF
--- a/chat.php
+++ b/chat.php
@@ -19,8 +19,10 @@ include __DIR__ . '/includes/header.php';
       <option value="offtopic">Off-topic</option>
     </select>
     <input type="text" id="chat-input" maxlength="250" placeholder="Type a message" autocomplete="off">
+    <button type="button" id="emoji-btn" class="aerobutton" aria-label="Emoji"></button>
     <button type="button" id="nudge-btn" class="aerobutton" aria-label="Nudge"></button>
-    <button type="submit" class="aerobutton" aria-label="Send"></button>
+    <button type="submit" id="send-btn" class="aerobutton" aria-label="Send"></button>
+    <div id="emoji-panel" class="emoji-panel"></div>
   </form>
   <audio id="nudge-sound" src="/img/nudge.mp3" preload="auto"></audio>
 </div>

--- a/css/xp.css
+++ b/css/xp.css
@@ -272,19 +272,26 @@ footer .sidebar li {
   margin-bottom: 8px;
 }
 .chat-form {
+  position: relative;
   display: flex;
   gap: 6px;
 }
 .chat-form button {
   background: url('/img/wlm/general/arrow.png') no-repeat center;
-  width: 32px;
-  height: 32px;
+  width: 24px;
+  height: 24px;
   border: 2px solid transparent;
   background-color: transparent;
 }
 .chat-form button:hover {
   background-image: url('/img/wlm/general/arrow_white.png');
   cursor: pointer;
+}
+.chat-form #emoji-btn {
+  background-image: url('/img/wlm/chat/select_emoticon.png');
+}
+.chat-form #emoji-btn:hover {
+  filter: brightness(1.2);
 }
 .chat-form #nudge-btn {
   background-image: url('/img/wlm/chat/send_nudge.png');
@@ -300,6 +307,31 @@ footer .sidebar li {
   flex: 1;
   padding: 4px;
   border: 1px solid #a0a5b0;
+}
+.emoji-panel {
+  position: absolute;
+  bottom: 36px;
+  left: 0;
+  display: none;
+  background: #fff;
+  border: 1px solid #a0a5b0;
+  padding: 4px;
+  max-height: 150px;
+  width: 200px;
+  overflow-y: auto;
+  flex-wrap: wrap;
+  z-index: 10;
+}
+.emoji-panel img {
+  width: 20px;
+  height: 20px;
+  margin: 2px;
+  cursor: pointer;
+}
+.emoji {
+  width: 20px;
+  height: 20px;
+  vertical-align: middle;
 }
 .chat-message {
   margin-bottom: 6px;

--- a/fetch_messages.php
+++ b/fetch_messages.php
@@ -6,7 +6,7 @@ if (!isset($_SESSION['user'])) {
 }
 $channel = $_GET['channel'] ?? 'general';
 require __DIR__ . '/includes/db.php';
-$limit = 50;
+$limit = 100;
 $stmt = $db->prepare('SELECT id, username, message, created FROM messages WHERE channel = ? ORDER BY id DESC LIMIT ?');
 $stmt->bindValue(1, $channel, PDO::PARAM_STR);
 $stmt->bindValue(2, $limit, PDO::PARAM_INT);

--- a/list_emoticons.php
+++ b/list_emoticons.php
@@ -1,0 +1,14 @@
+<?php
+session_start();
+if (!isset($_SESSION['user'])) {
+    http_response_code(403);
+    exit;
+}
+$files = glob(__DIR__ . '/img/wlm/emoticons/*.{png,gif}', GLOB_BRACE);
+$files = array_map(function($f) {
+    return '/img/wlm/emoticons/' . basename($f);
+}, $files);
+header('Content-Type: application/json');
+header('Cache-Control: no-cache');
+echo json_encode($files);
+


### PR DESCRIPTION
## Summary
- add emoji picker button with WLM emoticons
- hide emoji panel on submit, nudge and channel change
- limit chat window to last 25 messages
- shrink chat form buttons and style
- expose emoticon list via `list_emoticons.php`
- fetch up to 100 messages

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_685c567d07288320bf33a0e56191dded