### PR TITLE
Add call button and expand chat layout

### DIFF
--- a/chat.php
+++ b/chat.php
@@ -21,6 +21,7 @@ include __DIR__ . '/includes/header.php';
     <input type="text" id="chat-input" maxlength="250" placeholder="Type a message" autocomplete="off">
     <button type="button" id="emoji-btn" class="aerobutton" aria-label="Emoji"></button>
     <button type="button" id="nudge-btn" class="aerobutton" aria-label="Nudge"></button>
+    <button type="button" id="call-btn" class="aerobutton" aria-label="Call"></button>
     <div id="emoji-panel" class="emoji-panel"></div>
   </form>
   <audio id="nudge-sound" src="/img/nudge.mp3" preload="auto"></audio>

--- a/css/xp.css
+++ b/css/xp.css
@@ -242,6 +242,9 @@ footer .sidebar li {
   background: url('/img/wlm/background/chat_header.png') no-repeat top center;
   padding-top: 40px;
   position: relative;
+  display: flex;
+  flex-direction: column;
+  height: 500px;
 }
 
 .chat-panel h2 {
@@ -262,7 +265,7 @@ footer .sidebar li {
 .chat-window {
   background: #fff url('/img/wlm/background/chat_icons_background.png') repeat-x top;
   border: 1px solid #a0a5b0;
-  height: 300px;
+  flex: 1;
   overflow-y: auto;
   padding: 5px;
   margin-bottom: 10px;
@@ -309,6 +312,13 @@ footer .sidebar li {
   background-size: 16px 16px;
 }
 .chat-form #nudge-btn:hover {
+  filter: brightness(1.2);
+}
+.chat-form #call-btn {
+  background-image: url('/img/wlm/emoticons/telephone.png');
+  background-size: 16px 16px;
+}
+.chat-form #call-btn:hover {
   filter: brightness(1.2);
 }
 .chat-form select {

--- a/js/chat.js
+++ b/js/chat.js
@@ -104,6 +104,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const channelSelect = document.getElementById('chat-channel');
   const nudgeBtn = document.getElementById('nudge-btn');
   const emojiBtn = document.getElementById('emoji-btn');
+  const callBtn = document.getElementById('call-btn');
   const emojiPanel = document.getElementById('emoji-panel');
 
   fetch('list_emoticons.php')
@@ -151,6 +152,10 @@ document.addEventListener('DOMContentLoaded', () => {
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
       body: 'message=' + encodeURIComponent('/nudge') + '&channel=' + encodeURIComponent(getChannel())
     }).then(fetchMessages);
+    emojiPanel.style.display = 'none';
+  });
+  callBtn.addEventListener('click', () => {
+    window.open('https://meet.jit.si/' + encodeURIComponent(getChannel()), '_blank');
     emojiPanel.style.display = 'none';
   });
   fetchMessages();


### PR DESCRIPTION
## Summary
- adjust chat panel CSS to stretch the chat window
- make chat window fill the panel
- add a call button that opens a Jitsi room for the current channel

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685c5e5709b88320abb55e251a99b116