### PR TITLE
Implement call tracking and GIF uploads

### DIFF
--- a/account.php
+++ b/account.php
@@ -20,7 +20,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $name = bin2hex(random_bytes(8)) . $ext;
                 $dest = __DIR__ . '/../uploads/' . $name;
                 if (move_uploaded_file($_FILES['profile_file']['tmp_name'], $dest)) {
-                    $pic = '/uploads/' . $name;
+                    $pic = '/image.php?f=' . $name;
                 } else {
                     $error = 'Upload failed';
                 }

--- a/chat.php
+++ b/chat.php
@@ -11,6 +11,7 @@ include __DIR__ . '/includes/header.php';
 <div class="panel chat-panel">
   <h2><img width="40" src="https://upload.wikimedia.org/wikipedia/en/b/bf/Windows_Live_Messenger_icon.png" alt="">Chatroom</h2>
   <div id="chat-window" class="chat-window"></div>
+  <div id="call-info" class="call-info"></div>
   <div id="online-users" class="online-users"></div>
   <div class="users-pagination">
     <button type="button" id="users-prev" class="aerobutton">Prev</button>
@@ -24,10 +25,14 @@ include __DIR__ . '/includes/header.php';
       <option value="offtopic">Off-topic</option>
     </select>
     <input type="text" id="chat-input" maxlength="250" placeholder="Type a message" autocomplete="off">
+    <input type="file" id="image-input" accept="image/png,image/jpeg,image/gif" style="display:none">
     <button type="button" id="emoji-btn" class="aerobutton" aria-label="Emoji"></button>
     <button type="button" id="nudge-btn" class="aerobutton" aria-label="Nudge"></button>
     <button type="button" id="call-btn" class="aerobutton" aria-label="Call"></button>
+    <button type="button" id="upload-btn" class="aerobutton" aria-label="Upload"></button>
+    <button type="button" id="gif-btn" class="aerobutton" aria-label="GIF"></button>
     <div id="emoji-panel" class="emoji-panel"></div>
+    <div id="gif-panel" class="gif-panel"></div>
   </form>
   <audio id="nudge-sound" src="/img/nudge.mp3" preload="auto"></audio>
   <div id="call-modal" class="call-modal">

--- a/css/xp.css
+++ b/css/xp.css
@@ -275,6 +275,11 @@ footer .sidebar li {
   font-size: 13px;
   margin-bottom: 8px;
 }
+.call-info {
+  font-size: 13px;
+  margin-bottom: 4px;
+  color: #003399;
+}
 .users-pagination {
   display: flex;
   gap: 6px;
@@ -329,6 +334,20 @@ footer .sidebar li {
 .chat-form #call-btn:hover {
   filter: brightness(1.2);
 }
+.chat-form #upload-btn {
+  background-image: url('/img/wlm/chat/329.png');
+  background-size: 16px 16px;
+}
+.chat-form #upload-btn:hover {
+  filter: brightness(1.2);
+}
+.chat-form #gif-btn {
+  background-image: url('/img/wlm/emoticons/gift.png');
+  background-size: 16px 16px;
+}
+.chat-form #gif-btn:hover {
+  filter: brightness(1.2);
+}
 .chat-form select {
   padding: 4px;
   border: 1px solid #a0a5b0;
@@ -351,6 +370,24 @@ footer .sidebar li {
   overflow-y: auto;
   flex-wrap: wrap;
   z-index: 10;
+}
+.gif-panel {
+  position: absolute;
+  bottom: 36px;
+  right: 0;
+  display: none;
+  background: #fff;
+  border: 1px solid #a0a5b0;
+  padding: 4px;
+  max-height: 150px;
+  width: 200px;
+  overflow-y: auto;
+  z-index: 10;
+}
+.gif-panel img {
+  width: 100%;
+  margin-bottom: 4px;
+  cursor: pointer;
 }
 .emoji-panel img {
   width: 20px;
@@ -382,6 +419,12 @@ footer .sidebar li {
 .chat-message .time {
   color: #555;
   font-size: 11px;
+}
+.chat-img {
+  max-width: 150px;
+  max-height: 150px;
+  display: block;
+  margin-top: 4px;
 }
 .chat-panel.nudge {
   animation: shake 0.5s;

--- a/image.php
+++ b/image.php
@@ -1,0 +1,17 @@
+<?php
+session_start();
+if (!isset($_SESSION['user'])) {
+    http_response_code(403);
+    exit;
+}
+$file = basename($_GET['f'] ?? '');
+$path = __DIR__ . '/uploads/' . $file;
+if (!preg_match('/^[a-f0-9]{16}\.(png|jpe?g|gif)$/i', $file) || !is_file($path)) {
+    http_response_code(404);
+    exit;
+}
+$finfo = finfo_open(FILEINFO_MIME_TYPE);
+$type = finfo_file($finfo, $path);
+finfo_close($finfo);
+header('Content-Type: ' . $type);
+readfile($path);

--- a/upload_image.php
+++ b/upload_image.php
@@ -1,0 +1,28 @@
+<?php
+session_start();
+if (!isset($_SESSION['user'])) {
+    http_response_code(403);
+    exit;
+}
+if (!isset($_FILES['file']) || $_FILES['file']['error'] !== UPLOAD_ERR_OK) {
+    http_response_code(400);
+    exit;
+}
+if ($_FILES['file']['size'] > 2 * 1024 * 1024) {
+    http_response_code(400);
+    exit;
+}
+$info = getimagesize($_FILES['file']['tmp_name']);
+if (!$info || !in_array($info[2], [IMAGETYPE_PNG, IMAGETYPE_JPEG, IMAGETYPE_GIF])) {
+    http_response_code(400);
+    exit;
+}
+$ext = $info[2] === IMAGETYPE_GIF ? '.gif' : ($info[2] === IMAGETYPE_PNG ? '.png' : '.jpg');
+$name = bin2hex(random_bytes(8)) . $ext;
+$dest = __DIR__ . '/uploads/' . $name;
+if (!move_uploaded_file($_FILES['file']['tmp_name'], $dest)) {
+    http_response_code(500);
+    exit;
+}
+header('Content-Type: application/json');
+echo json_encode(['url' => '/image.php?f=' . $name]);


### PR DESCRIPTION
## Summary
- enable custom jitsi username and track users in call
- add popup displaying active call participants
- support image uploads and trending GIFs from Tenor
- show uploaded or Tenor images inline in chat
- secure uploaded files via image.php

## Testing
- `php` not available, so syntax not tested


------
https://chatgpt.com/codex/tasks/task_b_685c657c994c8320993fa020d49f1208