### PR TITLE
Fix chat image embed and simplify UI

### DIFF
--- a/chat.php
+++ b/chat.php
@@ -19,24 +19,23 @@ include __DIR__ . '/includes/header.php';
     <button type="button" id="users-next" class="aerobutton">Next</button>
   </div>
   <form id="chat-form" class="chat-form">
-    <div class="channel-buttons">
-      <button type="button" class="channel-btn active" data-channel="general">General</button>
-      <button type="button" class="channel-btn" data-channel="tech">Tech</button>
-      <button type="button" class="channel-btn" data-channel="offtopic">Off-topic</button>
-    </div>
-    <select id="chat-channel" style="display:none">
+    <select id="chat-channel">
       <option value="general" selected>General</option>
       <option value="tech">Tech</option>
       <option value="offtopic">Off-topic</option>
     </select>
     <input type="text" id="chat-input" maxlength="250" placeholder="Type a message" autocomplete="off">
     <input type="file" id="image-input" accept="image/png,image/jpeg,image/gif" style="display:none">
-    <button type="button" id="emoji-btn" class="aerobutton" aria-label="Emoji"></button>
-    <button type="button" id="nudge-btn" class="aerobutton" aria-label="Nudge"></button>
-    <button type="button" id="call-btn" class="aerobutton" aria-label="Call"></button>
-    <button type="button" id="upload-btn" class="aerobutton" aria-label="Upload"></button>
-    <button type="button" id="gif-btn" class="aerobutton" aria-label="GIF"></button>
-    <button type="button" id="draw-btn" class="aerobutton" aria-label="Draw"></button>
+    <div class="btn-row">
+      <button type="button" id="emoji-btn" class="aerobutton" aria-label="Emoji"></button>
+      <button type="button" id="nudge-btn" class="aerobutton" aria-label="Nudge"></button>
+      <button type="button" id="call-btn" class="aerobutton" aria-label="Call"></button>
+    </div>
+    <div class="btn-row">
+      <button type="button" id="upload-btn" class="aerobutton" aria-label="Upload"></button>
+      <button type="button" id="gif-btn" class="aerobutton" aria-label="GIF"></button>
+      <button type="button" id="draw-btn" class="aerobutton" aria-label="Draw"></button>
+    </div>
     <div id="emoji-panel" class="emoji-panel"></div>
     <div id="gif-panel" class="gif-panel">
       <input type="text" id="gif-search" placeholder="Search GIFs">

--- a/css/xp.css
+++ b/css/xp.css
@@ -296,25 +296,10 @@ footer .sidebar li {
   padding: 0 2px;
   border-radius: 2px;
 }
-.channel-buttons {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 4px;
-  margin-bottom: 6px;
-}
-.channel-buttons button {
-  background: #e8ecf4;
-  border: 1px solid #a0a5b0;
-  cursor: pointer;
-  padding: 2px 4px;
-}
-.channel-buttons button.active {
-  background: #d0e4ff;
-  border-color: #3a62a0;
-}
 .chat-form {
   position: relative;
   display: flex;
+  flex-direction: column;
   gap: 6px;
 }
 .chat-form button {
@@ -328,6 +313,11 @@ footer .sidebar li {
 .chat-form button:hover {
   filter: brightness(1.2);
   cursor: pointer;
+}
+.btn-row {
+  display: flex;
+  gap: 6px;
+  justify-content: flex-start;
 }
 .chat-form #emoji-btn {
   background-image: url('/img/wlm/chat/select_emoticon.png');
@@ -364,12 +354,20 @@ footer .sidebar li {
 .chat-form #gif-btn:hover {
   filter: brightness(1.2);
 }
+.chat-form #draw-btn {
+  background-image: url('/img/wlm/emoticons/note.png');
+  background-size: 16px 16px;
+}
+.chat-form #draw-btn:hover {
+  filter: brightness(1.2);
+}
 .chat-form select {
   padding: 4px;
   border: 1px solid #a0a5b0;
 }
 .chat-form input[type="text"] {
-  flex: 1;
+  width: 100%;
+  box-sizing: border-box;
   padding: 4px;
   border: 1px solid #a0a5b0;
 }

--- a/js/chat.js
+++ b/js/chat.js
@@ -14,7 +14,7 @@ let callUsers = new Set();
 
 function formatMessage(text) {
   let escaped = escapeHtml(text);
-  escaped = escaped.replace(/\[img:(https?:\/\/[^\s]+)\]/g, (m, url) => {
+  escaped = escaped.replace(/\[img:([^\]\s]+)\]/g, (m, url) => {
     const safe = url.replace(/"/g, '');
     return `<img src="${safe}" class="chat-img">`;
   });
@@ -179,7 +179,6 @@ document.addEventListener('DOMContentLoaded', () => {
   const gifPanel = document.getElementById('gif-panel');
   const gifSearch = document.getElementById('gif-search');
   const gifResults = document.getElementById('gif-results');
-  const channelButtons = document.querySelectorAll('.channel-btn');
   const drawBtn = document.getElementById('draw-btn');
   const drawModal = document.getElementById('draw-modal');
   const drawCanvas = document.getElementById('draw-canvas');
@@ -241,16 +240,6 @@ document.addEventListener('DOMContentLoaded', () => {
     lastMessageId = 0;
     fetchMessages();
     emojiPanel.style.display = 'none';
-  });
-  channelButtons.forEach(btn => {
-    btn.addEventListener('click', () => {
-      channelButtons.forEach(b => b.classList.remove('active'));
-      btn.classList.add('active');
-      channelSelect.value = btn.dataset.channel;
-      lastMessageId = 0;
-      fetchMessages();
-      emojiPanel.style.display = 'none';
-    });
   });
   emojiBtn.addEventListener('click', () => {
     emojiPanel.style.display = emojiPanel.style.display === 'block' ? 'none' : 'block';


### PR DESCRIPTION
## Summary
- restore channel dropdown and remove extra buttons
- group chat controls into rows
- show drawings and uploads correctly
- add icon for drawing tool

## Testing
- `node --check js/chat.js`


------
https://chatgpt.com/codex/tasks/task_b_685c6b060ec88320ac2ea710458b0b3c