### PR TITLE
Fix chat endpoints blocked by .htaccess redirect

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -9,8 +9,11 @@ RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteRule ^(.+)\.aspx$ $1.php [L]
 
-# Redirect direct .php requests to their .aspx versions without looping
-# Skip redirection if the request was already internally rewritten
+# Redirect direct .php requests for page routes to their .aspx
+# counterparts without affecting API endpoints. Skip redirection if the
+# request was already internally rewritten. This ensures AJAX calls to
+# scripts like send_message.php continue to work.
 RewriteCond %{ENV:REDIRECT_STATUS} ^$
 RewriteCond %{REQUEST_URI} \.php$
+RewriteCond %{REQUEST_URI} !^/(send_message|fetch_messages|fetch_users|upload_image|list_emoticons|captcha|image)\.php$
 RewriteRule ^(.+)\.php$ https://%{HTTP_HOST}/$1.aspx [R=301,L]

--- a/chat.php
+++ b/chat.php
@@ -26,6 +26,7 @@ include __DIR__ . '/includes/header.php';
     </select>
     <input type="text" id="chat-input" maxlength="250" placeholder="Type a message" autocomplete="off">
     <input type="file" id="image-input" accept="image/png,image/jpeg,image/gif" style="display:none">
+    <button type="submit" id="send-btn" class="aerobutton" aria-label="Send"></button>
     <div class="btn-row">
       <button type="button" id="emoji-btn" class="aerobutton" aria-label="Emoji"></button>
       <button type="button" id="nudge-btn" class="aerobutton" aria-label="Nudge"></button>

--- a/css/xp.css
+++ b/css/xp.css
@@ -354,6 +354,13 @@ footer .sidebar li {
 .chat-form #gif-btn:hover {
   filter: brightness(1.2);
 }
+.chat-form #send-btn {
+  background-image: url('/img/wlm/general/arrow.png');
+  background-size: 16px 16px;
+}
+.chat-form #send-btn:hover {
+  filter: brightness(1.2);
+}
 .chat-form #draw-btn {
   background-image: url('/img/wlm/chat/329.png');
   background-size: 16px 16px;


### PR DESCRIPTION
## Summary
- avoid redirecting AJAX PHP scripts to .aspx
- add send button back to chat UI

## Testing
- `node --check js/chat.js`


------
https://chatgpt.com/codex/tasks/task_b_685c99f726c48320892ba13a7b61a84e