### PR TITLE
Enable spacebar message sending

### DIFF
--- a/css/xp.css
+++ b/css/xp.css
@@ -355,11 +355,7 @@ footer .sidebar li {
   filter: brightness(1.2);
 }
 .chat-form #send-btn {
-  background-image: url('/img/wlm/general/arrow.png');
-  background-size: 16px 16px;
-}
-.chat-form #send-btn:hover {
-  filter: brightness(1.2);
+  display: none;
 }
 .chat-form #draw-btn {
   background-image: url('/img/wlm/chat/329.png');

--- a/js/chat.js
+++ b/js/chat.js
@@ -186,7 +186,15 @@ document.addEventListener('DOMContentLoaded', () => {
   const drawClear = document.getElementById('draw-clear');
   const drawClose = document.getElementById('draw-close');
   const callInfo = document.getElementById('call-info');
+  const chatInput = document.getElementById('chat-input');
   window.gifResults = gifResults;
+
+  chatInput.addEventListener('keydown', e => {
+    if (e.code === 'Space' && !e.shiftKey && !e.ctrlKey && !e.altKey && !e.metaKey) {
+      e.preventDefault();
+      form.dispatchEvent(new Event('submit', { cancelable: true }));
+    }
+  });
 
   fetch('list_emoticons.php')
     .then(r => r.json())


### PR DESCRIPTION
## Summary
- hide the send button
- trigger chat submission when the spacebar is pressed

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_b_685c9cf38d388320a4fc04a11f1c9b8b