### PR TITLE
Fix nudge spam check and update GIF API

### DIFF
--- a/js/chat.js
+++ b/js/chat.js
@@ -107,8 +107,8 @@ function fetchUsers() {
 
 function loadGifs(query = '') {
   const url = query
-    ? `https://g.tenor.com/v1/search?q=${encodeURIComponent(query)}&key=LIVDSRZULELA&limit=10`
-    : 'https://g.tenor.com/v1/trending?key=LIVDSRZULELA&limit=10';
+    ? `https://api.tenor.com/v1/search?q=${encodeURIComponent(query)}&key=LIVDSRZULELA&limit=10`
+    : 'https://api.tenor.com/v1/trending?key=LIVDSRZULELA&limit=10';
   fetch(url)
     .then(r => r.json())
     .then(d => {

--- a/send_message.php
+++ b/send_message.php
@@ -18,10 +18,10 @@ if (mb_strlen($input) > 250) {
 $check = $db->prepare('SELECT message, created FROM messages WHERE username = ? ORDER BY id DESC LIMIT 1');
 $check->execute([$_SESSION['user']]);
 $last = $check->fetch(PDO::FETCH_ASSOC);
-if ($last && $last['message'] === $input && strtotime($last['created']) > time() - 30) {
+$msg = $input === '/nudge' ? '::nudge::' : $input;
+if ($msg !== '::nudge::' && $last && $last['message'] === $msg && strtotime($last['created']) > time() - 30) {
     exit; // ignore spammy duplicate
 }
-$msg = $input === '/nudge' ? '::nudge::' : $input;
 if ($msg === '::nudge::') {
     $check = $db->prepare('SELECT created FROM messages WHERE username = ? AND message = "::nudge::" ORDER BY id DESC LIMIT 1');
     $check->execute([$_SESSION['user']]);


### PR DESCRIPTION
## Summary
- avoid duplicate nudge cooldown misfire by checking message after mapping
- switch GIF search URL to `api.tenor.com`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_685d3f1ab2fc8320921b2b05a2fc3599